### PR TITLE
Remap package import paths to github.com/piqosoft/gofeed

### DIFF
--- a/atom/feed.go
+++ b/atom/feed.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/mmcdole/gofeed/extensions"
+	"github.com/piqosoft/gofeed/extensions"
 )
 
 // Feed is an Atom Feed

--- a/atom/parser.go
+++ b/atom/parser.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 
 	"github.com/PuerkitoBio/goquery"
-	ext "github.com/mmcdole/gofeed/extensions"
-	"github.com/mmcdole/gofeed/internal/shared"
+	ext "github.com/piqosoft/gofeed/extensions"
+	"github.com/piqosoft/gofeed/internal/shared"
 	xpp "github.com/mmcdole/goxpp"
 )
 

--- a/atom/parser_test.go
+++ b/atom/parser_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mmcdole/gofeed/atom"
+	"github.com/piqosoft/gofeed/atom"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/cmd/ftest/main.go
+++ b/cmd/ftest/main.go
@@ -7,9 +7,9 @@ import (
 	"os"
 	"strings"
 
-	"github.com/mmcdole/gofeed"
-	"github.com/mmcdole/gofeed/atom"
-	"github.com/mmcdole/gofeed/rss"
+	"github.com/piqosoft/gofeed"
+	"github.com/piqosoft/gofeed/atom"
+	"github.com/piqosoft/gofeed/rss"
 	"github.com/urfave/cli"
 )
 

--- a/detector.go
+++ b/detector.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	jsoniter "github.com/json-iterator/go"
-	"github.com/mmcdole/gofeed/internal/shared"
+	"github.com/piqosoft/gofeed/internal/shared"
 	xpp "github.com/mmcdole/goxpp"
 )
 

--- a/detector_test.go
+++ b/detector_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mmcdole/gofeed"
+	"github.com/piqosoft/gofeed"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/extensions/extensions_test.go
+++ b/extensions/extensions_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mmcdole/gofeed"
+	"github.com/piqosoft/gofeed"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/feed.go
+++ b/feed.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"time"
 
-	ext "github.com/mmcdole/gofeed/extensions"
+	ext "github.com/piqosoft/gofeed/extensions"
 )
 
 // Feed is the universal Feed type that atom.Feed

--- a/feed_test.go
+++ b/feed_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mmcdole/gofeed"
+	"github.com/piqosoft/gofeed"
 )
 
 func TestFeedSort(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mmcdole/gofeed
+module github.com/piqosoft/gofeed
 
 go 1.19
 

--- a/internal/shared/extparser.go
+++ b/internal/shared/extparser.go
@@ -3,7 +3,7 @@ package shared
 import (
 	"strings"
 
-	"github.com/mmcdole/gofeed/extensions"
+	"github.com/piqosoft/gofeed/extensions"
 	"github.com/mmcdole/goxpp"
 )
 

--- a/json/feed.go
+++ b/json/feed.go
@@ -3,7 +3,7 @@ package json
 import (
 	"encoding/json"
 
-	ext "github.com/mmcdole/gofeed/extensions"
+	ext "github.com/piqosoft/gofeed/extensions"
 )
 
 // Feed describes the structure for JSON Feed v1.0

--- a/json/parser_test.go
+++ b/json/parser_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	jsonParser "github.com/mmcdole/gofeed/json"
+	jsonParser "github.com/piqosoft/gofeed/json"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/parser.go
+++ b/parser.go
@@ -9,9 +9,9 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/mmcdole/gofeed/atom"
-	"github.com/mmcdole/gofeed/json"
-	"github.com/mmcdole/gofeed/rss"
+	"github.com/piqosoft/gofeed/atom"
+	"github.com/piqosoft/gofeed/json"
+	"github.com/piqosoft/gofeed/rss"
 )
 
 // ErrFeedTypeNotDetected is returned when the detection system can not figure

--- a/parser_test.go
+++ b/parser_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mmcdole/gofeed"
+	"github.com/piqosoft/gofeed"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/podcast_test.go
+++ b/podcast_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/mmcdole/gofeed"
+	"github.com/piqosoft/gofeed"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/rss/feed.go
+++ b/rss/feed.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"time"
 
-	ext "github.com/mmcdole/gofeed/extensions"
+	ext "github.com/piqosoft/gofeed/extensions"
 )
 
 // Feed is an RSS Feed

--- a/rss/parser.go
+++ b/rss/parser.go
@@ -5,8 +5,8 @@ import (
 	"io"
 	"strings"
 
-	ext "github.com/mmcdole/gofeed/extensions"
-	"github.com/mmcdole/gofeed/internal/shared"
+	ext "github.com/piqosoft/gofeed/extensions"
+	"github.com/piqosoft/gofeed/internal/shared"
 	xpp "github.com/mmcdole/goxpp"
 )
 

--- a/rss/parser_test.go
+++ b/rss/parser_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mmcdole/gofeed/rss"
+	"github.com/piqosoft/gofeed/rss"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/translator.go
+++ b/translator.go
@@ -7,11 +7,11 @@ import (
 	"time"
 
 	"github.com/PuerkitoBio/goquery"
-	"github.com/mmcdole/gofeed/atom"
-	ext "github.com/mmcdole/gofeed/extensions"
-	"github.com/mmcdole/gofeed/internal/shared"
-	"github.com/mmcdole/gofeed/json"
-	"github.com/mmcdole/gofeed/rss"
+	"github.com/piqosoft/gofeed/atom"
+	ext "github.com/piqosoft/gofeed/extensions"
+	"github.com/piqosoft/gofeed/internal/shared"
+	"github.com/piqosoft/gofeed/json"
+	"github.com/piqosoft/gofeed/rss"
 	"golang.org/x/net/html"
 )
 

--- a/translator_test.go
+++ b/translator_test.go
@@ -8,10 +8,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mmcdole/gofeed"
-	"github.com/mmcdole/gofeed/atom"
-	"github.com/mmcdole/gofeed/json"
-	"github.com/mmcdole/gofeed/rss"
+	"github.com/piqosoft/gofeed"
+	"github.com/piqosoft/gofeed/atom"
+	"github.com/piqosoft/gofeed/json"
+	"github.com/piqosoft/gofeed/rss"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
This commit updates all import paths from github.com/mmcdole/gofeed to github.com/piqosoft/gofeed, allowing the fork to be used directly without affecting the upstream repository. This makes it easier to build applications that depend on this fork's podcast namespace extension support.

🤖 Generated with [Claude Code](https://claude.ai/code)